### PR TITLE
Add CLV prediction routes and update related services

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from interfaces.api.user_routes import user_bp
 from interfaces.api.insights_routes import insights_bp
 from interfaces.api.clustering_route import clustering_bp
 from interfaces.api.sku_metrics_routes import sku_metrics_bp
+from interfaces.api.clv_route import clv_bp
 from infra.clients.shopify import ShopifyClient
 from infra.clients.klaviyo import KlaviyoClient
 from application.services.segment_service import segment_service
@@ -20,6 +21,7 @@ def create_app():
     app.register_blueprint(insights_bp, url_prefix='/insights')
     app.register_blueprint(clustering_bp, url_prefix="/ml")
     app.register_blueprint(sku_metrics_bp, url_prefix='/insights')
+    app.register_blueprint(clv_bp, url_prefix='/clv')
 
     db_path = get_database_path()
     app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{db_path}"

--- a/domains/clv/data_pipeline/ml_pre_process.py
+++ b/domains/clv/data_pipeline/ml_pre_process.py
@@ -41,7 +41,8 @@ class CLVModelPreProcess:
     def pre_process_data(
         self,
         data: DataFrame,
-        target_variable: str
+        target_variable: str,
+        target_amount_of_months: int
     ) -> DataFrame:
         """
         Training pipeline:
@@ -52,7 +53,7 @@ class CLVModelPreProcess:
         """
         df = data.copy()
         # removes the last three month to avoid leakage during training
-        target_months = self._get_last_n_month_codes(df, 3)
+        target_months = self._get_last_n_month_codes(df, target_amount_of_months)
 
         df = self._create_target_variable(df, target_variable, target_months)
         df = self._remove_months(df, target_months)
@@ -61,7 +62,8 @@ class CLVModelPreProcess:
 
     def pre_process_inference_data(
         self,
-        data: DataFrame
+        data: DataFrame,
+        target_amount_of_months: int
     ) -> DataFrame:
         """
         Inference pipeline:
@@ -71,7 +73,7 @@ class CLVModelPreProcess:
         """
         df = data.copy()
         # removes the first three month so that the models gets the same width data as during training
-        drop_months = self._get_first_n_month_codes(df, 3)
+        drop_months = self._get_first_n_month_codes(df, target_amount_of_months)
 
         df = self._remove_months(df, drop_months)
         df = self._rename_month_columns(df)

--- a/domains/clv/two_stage_model.py
+++ b/domains/clv/two_stage_model.py
@@ -104,7 +104,6 @@ class TwoStageCLVModel:
         y_prob = self.training_classifier.predict_proba(self.X_test)[:, 1]
         y_reg = self.training_regressor.predict(self.X_test)
         y_pred = y_prob * y_reg
-        y_pred = y_pred.round()
         # Compute metrics
         self.mae = mean_absolute_error(self.y_test, y_pred)
         self.rmse = root_mean_squared_error(self.y_test, y_pred)
@@ -113,7 +112,7 @@ class TwoStageCLVModel:
     def _save_models_and_metadata(self) -> None:
         # Create version identifier
         self.version = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
-        version_dir = os.path.join(self.BASE_DIR, self.VERSION_DIR, self.version)
+        version_dir = os.path.join(self.BASE_DIR,self.target, self.VERSION_DIR, self.version)
         os.makedirs(version_dir, exist_ok=True, mode=0o755)
 
         # Save models
@@ -144,7 +143,7 @@ class TwoStageCLVModel:
         }
 
     def _load_models(self, version: str) -> Tuple[LGBMClassifier, LGBMRegressor]:
-        version_dir = os.path.join(self.BASE_DIR, self.VERSION_DIR, version)
+        version_dir = os.path.join(self.BASE_DIR, self.target, self.VERSION_DIR, version)
         clf = joblib.load(os.path.join(version_dir, 'classifier.pkl'))
         reg = joblib.load(os.path.join(version_dir, 'regressor.pkl'))
         return clf, reg
@@ -155,8 +154,8 @@ class TwoStageCLVModel:
         prob_buy = self.classifier.predict_proba(features)[:, 1]
         expected_spend = self.regressor.predict(features)
         result = prob_buy * expected_spend
-        result = result.round(2)
+        result = result
         return pd.DataFrame({
             "Email": emails,
-            "Prediction": result
+            f"{self.target}": result
         })

--- a/interfaces/api/clv_route.py
+++ b/interfaces/api/clv_route.py
@@ -1,0 +1,152 @@
+import os
+import threading
+from datetime import date
+from flask import Flask, Blueprint, jsonify
+from flask_cors import CORS
+import pandas as pd
+
+from application.services.clv_service import ClvService
+
+app = Flask(__name__)
+CORS(app)
+clv_bp = Blueprint('clv', __name__)
+service = ClvService()
+
+# Keep track of which model-targets are currently being trained
+training_tasks = set()
+training_lock = threading.Lock()
+
+def train_two_stage_model(cutoff_date, model_target_variable, target_amount_of_months):
+    train_df = service.run_data_pipeline(
+        from_api=False,
+        mode="train",
+        cutoff_date=cutoff_date,
+        model_target_variable=model_target_variable,
+        target_amount_of_months=target_amount_of_months,
+    )
+    service.create_models(train_df, model_target_variable=model_target_variable)
+
+    inference_df = service.run_data_pipeline(
+        from_api=False,
+        mode="inference",
+        cutoff_date=cutoff_date,
+        model_target_variable=model_target_variable,
+        target_amount_of_months=target_amount_of_months,
+    )
+    next_month_predictions = service.predict(inference_df)
+    pd.DataFrame(
+        next_month_predictions.round(2),
+        columns=["Email", model_target_variable]
+    ).to_csv(f"{model_target_variable}.csv", index=False)
+
+def kick_off_training_for(model_target_variable: str):
+    """
+    Spawn a thread to train just the specified model.
+    """
+    with training_lock:
+        if model_target_variable in training_tasks:
+            return  # already running
+        training_tasks.add(model_target_variable)
+
+    def _train_and_cleanup():
+        try:
+            if model_target_variable == "next_3_months_spend":
+                train_two_stage_model(cutoff_date=date(2025, 1, 1),
+                                      model_target_variable=model_target_variable,
+                                      target_amount_of_months=3)
+            else:  # next_1_months_spend
+                train_two_stage_model(cutoff_date=date(2025, 3, 1),
+                                      model_target_variable=model_target_variable,
+                                      target_amount_of_months=1)
+        finally:
+            with training_lock:
+                training_tasks.discard(model_target_variable)
+
+    thread = threading.Thread(target=_train_and_cleanup, daemon=True)
+    thread.start()
+
+@clv_bp.route('/predictions/next-three-months', methods=['GET'])
+def get_three_month_predictions():
+    fn = 'next_3_months_spend.csv'
+    if not os.path.isfile(fn):
+        kick_off_training_for("next_3_months_spend")
+        return (
+            jsonify({
+                "status": "pending",
+                "message": "Predictions are being generated. Please check back in a few minutes."
+            }),
+            202
+        )
+
+    df = pd.read_csv(fn)
+    return jsonify(df.to_dict(orient='records'))
+
+@clv_bp.route('/predictions/next-month', methods=['GET'])
+def get_next_month_prediction():
+    fn = 'next_1_months_spend.csv'
+    if not os.path.isfile(fn):
+        kick_off_training_for("next_1_months_spend")
+        return (
+            jsonify({
+                "status": "pending",
+                "message": "Predictions are being generated. Please check back in a few minutes."
+            }),
+            202
+        )
+
+    df = pd.read_csv(fn)
+    return jsonify(df.to_dict(orient='records'))
+
+@clv_bp.route('/predictions/', methods=['GET'])
+def get_clv_prediction_next_1_and_3_months():
+    # If either file is missing, tell the client to retry later.
+    missing = [
+        name for name in ("next_1_months_spend.csv", "next_3_months_spend.csv")
+        if not os.path.isfile(name)
+    ]
+    if missing:
+        # kick off whatever's missing
+        for var, fn in [("next_1_months_spend", "next_1_months_spend.csv"),
+                        ("next_3_months_spend", "next_3_months_spend.csv")]:
+            if fn in missing:
+                kick_off_training_for(var)
+        return (
+            jsonify({
+                "status": "pending",
+                "message": "Some predictions are still being generated. Please try again in a few minutes."
+            }),
+            202
+        )
+
+    # both files exist: merge and return
+    df1 = pd.read_csv('next_1_months_spend.csv')
+    df3 = pd.read_csv('next_3_months_spend.csv')
+    combined = df1.merge(df3, on='Email')
+    return jsonify(combined.to_dict(orient='records'))
+
+@clv_bp.route('/lifetime', methods=['GET'])
+def get_lifetime_clv():
+    df_lifetime_clv = service.get_lifetime_clv()
+    return jsonify(df_lifetime_clv.to_dict(orient='records'))
+
+@clv_bp.route('/lifetime_clv_distribution', methods=['GET'])
+def get_lifetime_clv_distribution():
+    df_lifetime_clv = service.get_lifetime_clv()
+    # Create bins for CLV ranges
+    bins = [0, 50, 100, 200, 300, 400, 500, float('inf')]
+    labels = ['0-50', '50-100', '100-200', '200-300', '300-400', '400-500', '500+']
+    
+    # Add a new column with the binned values
+    df_lifetime_clv['CLV_Range'] = pd.cut(df_lifetime_clv['Lifetime CLV'], bins=bins, labels=labels)
+    
+    # Count customers in each bin
+    distribution = df_lifetime_clv['CLV_Range'].value_counts().sort_index()
+    
+    # Convert to dictionary format for JSON response
+    result = {
+        'distribution': {
+            range_name: int(count) for range_name, count in distribution.items()
+        }
+    }
+    
+    return jsonify(result)

--- a/interfaces/api/insights_routes.py
+++ b/interfaces/api/insights_routes.py
@@ -1,4 +1,3 @@
-from fastapi import APIRouter, Query
 from flask import Blueprint, jsonify, request
 from application.services.insights_service import DiscountCodeService
 from application.services.get_top_sku_stats import SkuStatsService

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,139 @@
+url: http://localhost:5000
+paths:
+  /clv/predictions/next-three-months:
+    get:
+      summary: Get predictions for the next three months
+      responses:
+        '200':
+          description: A JSON array of next three months CLV predictions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NextThreeMonthsPrediction'
+        '202':
+          description: Predictions are being generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingResponse'
+  /clv/predictions/next-month:
+    get:
+      summary: Get prediction for the next month
+      responses:
+        '200':
+          description: A JSON array of next month CLV predictions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NextMonthPrediction'
+        '202':
+          description: Prediction is being generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingResponse'
+  /clv/predictions:
+    get:
+      summary: Get predictions for next one and three months
+      responses:
+        '200':
+          description: A JSON array of combined CLV predictions for next one and three months
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CombinedPrediction'
+        '202':
+          description: Some predictions are still being generated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PendingResponse'
+  /clv/lifetime:
+    get:
+      summary: Get lifetime CLV for all customers
+      responses:
+        '200':
+          description: A JSON array of lifetime CLV records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LifetimeClvRecord'
+  /clv/lifetime_clv_distribution:
+    get:
+      summary: Get distribution of lifetime CLV values in predefined ranges
+      responses:
+        '200':
+          description: A JSON object mapping CLV ranges to customer counts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LifetimeClvDistribution'
+components:
+  schemas:
+    PendingResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: pending
+        message:
+          type: string
+          example: Predictions are being generated. Please check back in a few minutes.
+    NextThreeMonthsPrediction:
+      type: object
+      properties:
+        Email:
+          type: string
+          format: email
+        next_3_months_spend:
+          type: number
+          format: float
+          description: Predicted spend over the next three months
+    NextMonthPrediction:
+      type: object
+      properties:
+        Email:
+          type: string
+          format: email
+        next_1_months_spend:
+          type: number
+          format: float
+          description: Predicted spend over the next month
+    CombinedPrediction:
+      type: object
+      properties:
+        Email:
+          type: string
+          format: email
+        next_1_months_spend:
+          type: number
+          format: float
+        next_3_months_spend:
+          type: number
+          format: float
+    LifetimeClvRecord:
+      type: object
+      properties:
+        Email:
+          type: string
+          format: email
+        Lifetime CLV:
+          type: number
+          format: float
+          description: Lifetime customer value
+    LifetimeClvDistribution:
+      type: object
+      properties:
+        distribution:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Mapping of CLV range labels to customer counts

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,13 +14,5 @@ SQLAlchemy==2.0.30
 Flask-Migrate==4.1.0
 joblib==1.5.1 
 scikit-learn==1.7.0
-threadpoolctl==3.6.0
 flask-cors==6.0.0
 shopifyapi==12.3.0
-hdbscan==0.8.40
-annotated-types==0.7.0 
-fastapi==0.115.12 
-pydantic==2.11.5 
-pydantic-core==2.33.2 
-starlette==0.46.2 
-typing-inspection==0.4.1  


### PR DESCRIPTION
- Introduced new CLV prediction endpoints in clv_route.py.
- Updated ClvService to handle new parameters for data pipeline.
- CLV model can now predict for either the next month, three months, four month etc..
- Enhanced data processing in ml_pre_process.py to accommodate dynamic target months.
- Added OpenAPI specifications for new endpoints.
- Cleaned up unused imports in insights_routes.py.